### PR TITLE
Update 7-12-21.md - Fix typo

### DIFF
--- a/content/posts/7-12-21.md
+++ b/content/posts/7-12-21.md
@@ -306,7 +306,7 @@ architecture](https://en.wikipedia.org/wiki/Endianness), meaning that the least
 significant byte is stored at the smallest memory address. If we take the 4
 bytes at `0x101b8`, which is the location of our `addw` instruction, we can
 re-arrange the bytes so that the least significant bit (LSB) is on the right and
-the most significant bit (MSB) is on the right:
+the most significant bit (MSB) is on the left:
 
 `00000000 10110101 00000101 00111011`
 


### PR DESCRIPTION
Fix typo in endianess description: corrected MSB position from 'right' to 'left'